### PR TITLE
Remove warnings caused by -Wall -Wpedantic

### DIFF
--- a/src/nsntrace.c
+++ b/src/nsntrace.c
@@ -205,8 +205,12 @@ _nsntrace_start_tracee(struct nsntrace_options *options)
 		uid = getuid();
 		gid = getgid();
 	}
-	setgid(gid);
-	setuid(uid);
+	if (setgid(gid) < 0) {
+		fprintf(stderr, "Unable to set process GID");
+	}
+	if (setuid(uid) < 0) {
+		fprintf(stderr, "Unable to set process UID");
+	}
 	/*
 	 * Should we wait here until we know capturing has started before
 	 * launching the application? If so, how?

--- a/src/nsntrace.c
+++ b/src/nsntrace.c
@@ -206,10 +206,10 @@ _nsntrace_start_tracee(struct nsntrace_options *options)
 		gid = getgid();
 	}
 	if (setgid(gid) < 0) {
-		fprintf(stderr, "Unable to set process GID");
+		fprintf(stderr, "Unable to set process group ID");
 	}
 	if (setuid(uid) < 0) {
-		fprintf(stderr, "Unable to set process UID");
+		fprintf(stderr, "Unable to set process user ID");
 	}
 	/*
 	 * Should we wait here until we know capturing has started before


### PR DESCRIPTION
There was a warning while compiling because of unhandled return values.