### PR TITLE
Put libs in LDADD to fix FTBFS with ld --as-needed

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -15,4 +15,5 @@ sources =			\
 
 nsntrace_SOURCES = $(headers) $(sources)
 nsntrace_CPPFLAGS = $(LIBNL_CFLAGS) $(warnings)
-nsntrace_LDFLAGS = $(LIBNL_LIBS) -pthread
+nsntrace_LDFLAGS = -pthread
+nsntrace_LDADD = $(LIBNL_LIBS)


### PR DESCRIPTION
nsntrace currently fails to build from source (FTBFS) in Ubuntu because the linking order does not meet the requirements for ld --as-needed: https://launchpadlibrarian.net/277692321/buildlog_ubuntu-yakkety-amd64.nsntrace_0~20160806-1_BUILDING.txt.gz

This commit puts the libs in the correct location, LDADD instead of LDFLAGS, to fix this FTBFS.